### PR TITLE
Fix bug when serialization_options get persisted for an object

### DIFF
--- a/lib/serialization_extensions.rb
+++ b/lib/serialization_extensions.rb
@@ -27,6 +27,9 @@ module SerializationExtensions
       end
     end
 
+    # Clear the serialization options since they should not be persisted for the same object
+    @serialization_options = nil
+
     options[:except] = Array.wrap(options[:except]) + self.class.excluded_from_serialization
 
     result = serializable_hash_without_extensions(options)
@@ -89,12 +92,12 @@ module SerializationExtensions
       end
     end
 
-    def included?(serialization_options)
+    def included?(options)
       case
-      when serialization_options[:except] && serialization_options[:except].include?(key)
+      when options[:except] && options[:except].include?(key)
         false
 
-      when serialization_options[:only] && !serialization_options[:only].include?(key)
+      when options[:only] && !options[:only].include?(key)
         false
 
       else


### PR DESCRIPTION
So let me explain a bit what we found:

```
class Enquiry
  has_many messages, class: EnquiryMessage
end

class EnquiryMessage
  belongs_to :enquiry
end
```

On Rails4, when we build a message for a particular enquiry, and then try to:

```
@message.serialize_with(include: :enquiry)
@message.to_json
```

It will start to recursively call itself, make the application lock. This is because in rails 4, the object inside the enquiry.messages.first is the exact same object as `@message`, and so it will try to include again the `enquiry` when serializing.

Rails 3 does not have this problem because `enquiry.messages.first.object_id != @message.object_id`.
